### PR TITLE
update readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Backend is build both in php and go.
 
 ## Frontend Repository
 
-(Ecoland-Apps)[https://github.com/FiSeStRo/Ecoland-Apps]
+[Ecoland-Apps](https://github.com/FiSeStRo/Ecoland-Apps)
 
 ## Usage
 
@@ -16,5 +16,5 @@ The Backend is build both in php and go.
 
 ## API Documentation
 
-(Docs)[https://e04rd7wcgr.apidog.io]
-(OpenAPI)[/docs/openapi.yaml]
+[Docs](https://e04rd7wcgr.apidog.io)
+[OpenAPI](./docs/api/openapi.yaml)


### PR DESCRIPTION
This pull request includes changes to the `README.md` file to correct markdown link syntax and update the OpenAPI documentation link.

Markdown link corrections:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R10): Corrected the syntax for the "Ecoland-Apps" link to properly format the markdown.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R20): Corrected the syntax for the "Docs" and "OpenAPI" links to properly format the markdown and updated the OpenAPI link to a relative path.