### PR TITLE
add cancel service

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main]
 jobs:
-  test:
+  test-go:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
 jobs:
   test-go:
     runs-on: ubuntu-latest

--- a/go/database/databaseTypes.go
+++ b/go/database/databaseTypes.go
@@ -49,3 +49,15 @@ type UserResource struct {
 	Money    float64 `json:"money"`
 	Prestige int     `json:"prestige"`
 }
+
+type Production struct {
+	Id           int
+	BuildingId   int
+	ProductionId int
+	TimeStart    int
+	TimeEnd      int
+	Cycles       int
+	IsCompleted  bool
+}
+
+const RelBuildingDefProductionTable = "rel_building_def_production"

--- a/go/database/dbProduction.go
+++ b/go/database/dbProduction.go
@@ -1,0 +1,12 @@
+package database
+
+func FindProductionById(id int) (Production, error) {
+
+	var production Production
+	row := db.QueryRow(`SELECT * FROM ? WHERE id=?`, RelBuildingDefProductionTable, id)
+	err := row.Scan(&production.Id, &production.BuildingId, &production.ProductionId, &production.TimeStart, &production.TimeEnd, &production.IsCompleted)
+	if err != nil {
+		return Production{}, nil
+	}
+	return production, nil
+}

--- a/go/main.go
+++ b/go/main.go
@@ -67,6 +67,7 @@ func main() {
 	//production
 	http.HandleFunc("/production/list", service.ListOfProductions)
 	http.HandleFunc("/production/start", service.StartProduction)
+	http.HandleFunc("/production/cancel", service.CancelProduction)
 
 	// user
 	http.HandleFunc("/user/resources", service.GetUserResources)

--- a/go/utils/reqMethod.go
+++ b/go/utils/reqMethod.go
@@ -23,3 +23,12 @@ func IsMethodGET(w http.ResponseWriter, req *http.Request) bool {
 
 	return true
 }
+
+func IsMethodDELET(w http.ResponseWriter, req *http.Request) bool {
+	if req.Method != http.MethodDelete {
+		w.Header().Set("Allow", "DELETE")
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return false
+	}
+	return true
+}

--- a/go/utils/reqParams.go
+++ b/go/utils/reqParams.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type UrlParam struct {
+	Url      string
+	Position int
+}
+
+func GetUrlParamId(path UrlParam) (int, error) {
+	pathParts := strings.Split(path.Url, "/")
+	if len(pathParts) != path.Position+1 {
+		return 0, fmt.Errorf("wrong path")
+	}
+
+	id := pathParts[path.Position]
+
+	return strconv.Atoi(id)
+}


### PR DESCRIPTION
This pull request introduces several new features and enhancements related to production management in the Go backend. The most important changes include the addition of a new `Production` type, a new endpoint to cancel production, and utility functions to handle request methods and URL parameters.

### New Features:

* **Production Management:**
  * Added a new `Production` struct and constant `RelBuildingDefProductionTable` in `go/database/databaseTypes.go`.
  * Implemented `FindProductionById` function in `go/database/dbProduction.go` to retrieve production details by ID.
  * Added a new endpoint `/production/cancel` in `go/main.go` to handle production cancellation requests.
  * Created `CancelProduction` function in `go/service/production.go` to process production cancellation, including validation and deletion logic.

### Utility Functions:

* **Request Handling:**
  * Added `IsMethodDELET` function in `go/utils/reqMethod.go` to validate DELETE HTTP requests.
  * Introduced `GetUrlParamId` function in `go/utils/reqParams.go` to extract and convert URL parameters to integers.

### Workflow Update:

* **CI/CD:**
  * Renamed the test job from `test` to `test-go` in the GitHub workflow configuration file `.github/workflows/go_test.yml`.