### PR TITLE
add php api test to ci actions

### DIFF
--- a/.github/workflows/go_api_test.yml
+++ b/.github/workflows/go_api_test.yml
@@ -34,7 +34,7 @@ jobs:
           echo "DB_HOST=${{secrets.DB_HOST}}" >> go/.env
           echo "DB_PORT=${{ secrets.DB_PORT }}" >> go/.env
           echo "DB_NAME=${{ secrets.DB_NAME }}" >> go/.env
-          echo "JWT_KEY=${{secrets.JWT_KEY}}" >> go/.env
+          echo "JWT_SECRET=${{secrets.JWT_KEY}}" >> go/.env
           echo "JWT_EXPIRATION_TIME_AT=${{secrets.JWT_EXPIRATION_TIME_AT}}" >> go/.env
           echo "JWT_EXPIRATION_TIME_RT=${{secrets.JWT_EXPIRATION_TIME_AT}}" >> go/.env
           echo "JWT_ISSUER=${{secrets.JWT_ISSUER}}" >> go/.env

--- a/.github/workflows/go_api_test.yml
+++ b/.github/workflows/go_api_test.yml
@@ -34,7 +34,7 @@ jobs:
           echo "DB_HOST=${{secrets.DB_HOST}}" >> go/.env
           echo "DB_PORT=${{ secrets.DB_PORT }}" >> go/.env
           echo "DB_NAME=${{ secrets.DB_NAME }}" >> go/.env
-          echo "JWT_SECRET=${{secrets.JWT_KEY}}" >> go/.env
+          echo "JWT_SECRET=${{secrets.JWT_SECRET}}" >> go/.env
           echo "JWT_EXPIRATION_TIME_AT=${{secrets.JWT_EXPIRATION_TIME_AT}}" >> go/.env
           echo "JWT_EXPIRATION_TIME_RT=${{secrets.JWT_EXPIRATION_TIME_AT}}" >> go/.env
           echo "JWT_ISSUER=${{secrets.JWT_ISSUER}}" >> go/.env

--- a/.github/workflows/go_api_test.yml
+++ b/.github/workflows/go_api_test.yml
@@ -46,7 +46,7 @@ jobs:
           DB_HOST: ${{ secrets.DB_HOST }}
           DB_NAME: ${{ secrets.DB_NAME }}
           DB_PORT: ${{ secrets.DB_PORT }}
-        run: docker-compose --profile go up -d
+        run: docker compose --profile go up -d
 
       - name: Check container status
         run: docker ps
@@ -83,4 +83,4 @@ jobs:
           APIDOG_ACCESS_TOKEN: ${{ secrets.APIDOG_ACCESS_TOKEN }}
 
       - name: Shutdown Docker Compose services
-        run: docker-compose --profile go down
+        run: docker compose --profile go down

--- a/.github/workflows/go_api_test.yml
+++ b/.github/workflows/go_api_test.yml
@@ -46,7 +46,7 @@ jobs:
           DB_HOST: ${{ secrets.DB_HOST }}
           DB_NAME: ${{ secrets.DB_NAME }}
           DB_PORT: ${{ secrets.DB_PORT }}
-        run: docker compose --profile go up -d
+        run: docker-compose --profile go up -d
 
       - name: Check container status
         run: docker ps
@@ -83,4 +83,4 @@ jobs:
           APIDOG_ACCESS_TOKEN: ${{ secrets.APIDOG_ACCESS_TOKEN }}
 
       - name: Shutdown Docker Compose services
-        run: docker-compose down
+        run: docker-compose --profile go down

--- a/.github/workflows/go_api_test.yml
+++ b/.github/workflows/go_api_test.yml
@@ -42,7 +42,7 @@ jobs:
           DB_HOST: ${{ secrets.DB_HOST }}
           DB_NAME: ${{ secrets.DB_NAME }}
           DB_PORT: ${{ secrets.DB_PORT }}
-        run: docker compose up -d
+        run: docker compose --profile go up -d
 
       - name: Check container status
         run: docker ps
@@ -52,7 +52,7 @@ jobs:
           for i in {1..30}; do
             docker ps
             if curl -s http://localhost:8081/; then
-              echo ""Service is up and helthy""
+              echo ""Service is up and healthy""
               exit 0
             fi
             echo "Waiting for service..."

--- a/.github/workflows/php_api_test.yml
+++ b/.github/workflows/php_api_test.yml
@@ -53,8 +53,8 @@ jobs:
           for i in {1..30}; do
             docker ps
             if curl -s http://localhost:8080/; then
-              curl -s http://loclahost8080/admin/setupDatabase
-              curl -s http://localhost8080/admin/initDefinitionData
+              curl -s http://loclahost:8080/admin/setupDatabase
+              curl -s http://localhost:8080/admin/initDefinitionData
               echo ""PhP Service is up and healthy""
               exit 0
             fi
@@ -78,4 +78,4 @@ jobs:
           APIDOG_ACCESS_TOKEN: ${{ secrets.APIDOG_ACCESS_TOKEN }}
 
       - name: Shutdown Docker Compose services
-        run: docker-compose --profile php down
+        run: docker compose --profile php down

--- a/.github/workflows/php_api_test.yml
+++ b/.github/workflows/php_api_test.yml
@@ -53,8 +53,7 @@ jobs:
           for i in {1..30}; do
             docker ps
             if curl -s http://localhost:8080/; then
-              curl -s http://loclahost:8080/admin/setupDatabase
-              curl -s http://localhost:8080/admin/initDefinitionData
+
               echo ""PhP Service is up and healthy""
               exit 0
             fi

--- a/.github/workflows/php_api_test.yml
+++ b/.github/workflows/php_api_test.yml
@@ -29,7 +29,7 @@ jobs:
           echo "DB_HOST=${{secrets.DB_HOST}}" >> php/.env
           echo "DB_PORT=${{ secrets.DB_PORT }}" >> php/.env
           echo "DB_NAME=${{ secrets.DB_NAME }}" >> php/.env
-          echo "JWT_SECRET=${{secrets.JWT_KEY}}" >> php/.env
+          echo "JWT_SECRET=${{secrets.JWT_SECRET}}" >> php/.env
           echo "JWT_EXPIRATION_TIME_AT=${{secrets.JWT_EXPIRATION_TIME_AT}}" >> php/.env
           echo "JWT_EXPIRATION_TIME_RT=${{secrets.JWT_EXPIRATION_TIME_AT}}" >> php/.env
           echo "JWT_ISSUER=${{secrets.JWT_ISSUER}}" >> php/.env

--- a/.github/workflows/php_api_test.yml
+++ b/.github/workflows/php_api_test.yml
@@ -21,7 +21,19 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y docker-compose
 
-        # create php env
+      - name: Create php/.env file
+        run: |
+          mkdir -p php
+          echo "DB_USER=${{ secrets.DB_USER }}" > php/.env
+          echo "DB_PW=${{ secrets.DB_PW }}" >> php/.env
+          echo "DB_HOST=${{secrets.DB_HOST}}" >> php/.env
+          echo "DB_PORT=${{ secrets.DB_PORT }}" >> php/.env
+          echo "DB_NAME=${{ secrets.DB_NAME }}" >> php/.env
+          echo "JWT_SECRET=${{secrets.JWT_KEY}}" >> php/.env
+          echo "JWT_EXPIRATION_TIME_AT=${{secrets.JWT_EXPIRATION_TIME_AT}}" >> php/.env
+          echo "JWT_EXPIRATION_TIME_RT=${{secrets.JWT_EXPIRATION_TIME_AT}}" >> php/.env
+          echo "JWT_ISSUER=${{secrets.JWT_ISSUER}}" >> php/.env
+
       - name: Start docker-compose service
         env:
           DB_PW: ${{ secrets.DB_PW }}
@@ -29,6 +41,10 @@ jobs:
           DB_HOST: ${{ secrets.DB_HOST }}
           DB_NAME: ${{ secrets.DB_NAME }}
           DB_PORT: ${{ secrets.DB_PORT }}
+          JWT_EXPIRATION_TIME_AT: ${{secrets.JWT_EXPIRATION_TIME_AT}}
+          JWT_EXPIRATION_TIME_RT: ${{secrets.JWT_EXPIRATION_TIME_RT}}
+          JWT_SECRET: ${{secrets.JWT_SECRET}}
+          JWT_ISSUER: ${{secrets.JWT_ISSUER}}
         run: |
           docker compose --profile php up -d
           docker ps

--- a/.github/workflows/php_api_test.yml
+++ b/.github/workflows/php_api_test.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Create php/.env file
         run: |
           mkdir -p php
-          echo "DB_USER=${{ secrets.DB_USER }}" > php/.env
-          echo "DB_PW=${{ secrets.DB_PW }}" >> php/.env
-          echo "DB_HOST=${{secrets.DB_HOST}}" >> php/.env
-          echo "DB_PORT=${{ secrets.DB_PORT }}" >> php/.env
-          echo "DB_NAME=${{ secrets.DB_NAME }}" >> php/.env
+          echo "DB_USER=maria" > php/.env
+          echo "DB_PW=maria123" >> php/.env
+          echo "DB_HOST=mariadb-service" >> php/.env
+          echo "DB_PORT=3306" >> php/.env
+          echo "DB_NAME=mariadb" >> php/.env
           echo "JWT_SECRET=${{secrets.JWT_SECRET}}" >> php/.env
           echo "JWT_EXPIRATION_TIME_AT=${{secrets.JWT_EXPIRATION_TIME_AT}}" >> php/.env
           echo "JWT_EXPIRATION_TIME_RT=${{secrets.JWT_EXPIRATION_TIME_AT}}" >> php/.env
@@ -36,11 +36,11 @@ jobs:
 
       - name: Start docker-compose service
         env:
-          DB_PW: ${{ secrets.DB_PW }}
-          DB_USER: ${{ secrets.DB_USER }}
-          DB_HOST: ${{ secrets.DB_HOST }}
-          DB_NAME: ${{ secrets.DB_NAME }}
-          DB_PORT: ${{ secrets.DB_PORT }}
+          DB_PW: maria123
+          DB_USER: maria
+          DB_HOST: mariadb-service
+          DB_NAME: mariadb
+          DB_PORT: 3306
           JWT_EXPIRATION_TIME_AT: ${{secrets.JWT_EXPIRATION_TIME_AT}}
           JWT_EXPIRATION_TIME_RT: ${{secrets.JWT_EXPIRATION_TIME_RT}}
           JWT_SECRET: ${{secrets.JWT_SECRET}}

--- a/.github/workflows/php_api_test.yml
+++ b/.github/workflows/php_api_test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Create php/.env file
         run: |
           mkdir -p php
-          echo "DB_USER=maria" > php/.env
+          echo "DB_USER=ruendelbrunft" > php/.env
           echo "DB_PW=maria123" >> php/.env
           echo "DB_HOST=mariadb-service" >> php/.env
           echo "DB_PORT=3306" >> php/.env

--- a/.github/workflows/php_api_test.yml
+++ b/.github/workflows/php_api_test.yml
@@ -53,7 +53,8 @@ jobs:
           for i in {1..30}; do
             docker ps
             if curl -s http://localhost:8080/; then
-
+              curl -s http://localhost:8080/admin/setupDatabase; then
+              curl -s http://localhost:8080/admin/initDefinitionData; then
               echo ""PhP Service is up and healthy""
               exit 0
             fi

--- a/.github/workflows/php_api_test.yml
+++ b/.github/workflows/php_api_test.yml
@@ -53,6 +53,8 @@ jobs:
           for i in {1..30}; do
             docker ps
             if curl -s http://localhost:8080/; then
+              curl -s http://loclahost8080/admin/setupDatabase
+              curl -s http://localhost8080/admin/initDefinitionData
               echo ""PhP Service is up and healthy""
               exit 0
             fi
@@ -76,4 +78,4 @@ jobs:
           APIDOG_ACCESS_TOKEN: ${{ secrets.APIDOG_ACCESS_TOKEN }}
 
       - name: Shutdown Docker Compose services
-        run: docker-compose down
+        run: docker-compose --profile php down

--- a/.github/workflows/php_api_test.yml
+++ b/.github/workflows/php_api_test.yml
@@ -53,8 +53,6 @@ jobs:
           for i in {1..30}; do
             docker ps
             if curl -s http://localhost:8080/; then
-              curl -s http://localhost:8080/admin/setupDatabase; then
-              curl -s http://localhost:8080/admin/initDefinitionData; then
               echo ""PhP Service is up and healthy""
               exit 0
             fi
@@ -63,10 +61,16 @@ jobs:
           done
           echo "Service did not become ready in time." >&2
           exit 1
-          - name: Setup Node.js environment
-          uses: actions/setup-node@v2
-          with:
-            node-version: "14"
+
+      - name: Setup php data
+        run: |
+          curl -s http://localhost:8080/admin/setupDatabase
+          curl -s http://localhost:8080/admin/initDefinitionData
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14"
 
       - name: Install Apidog CLI
         run: npm install -g apidog-cli

--- a/.github/workflows/php_api_test.yml
+++ b/.github/workflows/php_api_test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Create php/.env file
         run: |
           mkdir -p php
-          echo "DB_USER=ruendelbrunft" > php/.env
+          echo "DB_USER=maria" > php/.env
           echo "DB_PW=maria123" >> php/.env
           echo "DB_HOST=mariadb-service" >> php/.env
           echo "DB_PORT=3306" >> php/.env

--- a/.github/workflows/php_api_test.yml
+++ b/.github/workflows/php_api_test.yml
@@ -1,0 +1,63 @@
+name: PhP e2e Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - "**.php"
+      - "composer.json"
+
+jobs:
+  test-php:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: setup docker-compose
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docker-compose
+
+        # create php env
+      - name: Start docker-compose service
+        env:
+          DB_PW: ${{ secrets.DB_PW }}
+          DB_USER: ${{ secrets.DB_USER }}
+          DB_HOST: ${{ secrets.DB_HOST }}
+          DB_NAME: ${{ secrets.DB_NAME }}
+          DB_PORT: ${{ secrets.DB_PORT }}
+        run: |
+          docker compose --profile php up -d
+          docker ps
+      - name: Wait for API services to be ready
+        run: |
+          for i in {1..30}; do
+            docker ps
+            if curl -s http://localhost:8080/; then
+              echo ""PhP Service is up and healthy""
+              exit 0
+            fi
+            echo "Waiting for service..."
+            sleep 2
+          done
+          echo "Service did not become ready in time." >&2
+          exit 1
+          - name: Setup Node.js environment
+          uses: actions/setup-node@v2
+          with:
+            node-version: "14"
+
+      - name: Install Apidog CLI
+        run: npm install -g apidog-cli
+
+      - name: Run API Test Scenarios
+        run: |
+          apidog run --access-token $APIDOG_ACCESS_TOKEN -t 831275 -e 2583121 -n 1 -r html,cli
+        env:
+          APIDOG_ACCESS_TOKEN: ${{ secrets.APIDOG_ACCESS_TOKEN }}
+
+      - name: Shutdown Docker Compose services
+        run: docker-compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,10 +35,12 @@ services:
     ports:
       - "3306:3306"
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
-      interval: 10s
+      test: [ "CMD", "healthcheck.sh", "--su-mysql", "--connect", "--innodb_initialized" ]
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
       timeout: 5s
-      retries: 5
+      retries: 3
   redis:
     image: redis:latest
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     - "8080:80"
     depends_on:
       mariadb-service:
-        condition: service_started
+        condition: service_healthy
   go-be-service:
     profiles:
       - go
@@ -34,6 +34,11 @@ services:
       MYSQL_PASSWORD: ${DB_PW}
     ports:
       - "3306:3306"
+    healthcheck:
+    test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+    interval: 10s
+    timeout: 5s
+    retries: 5
   redis:
     image: redis:latest
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,13 @@
 services:
   php-be-service:
+    profiles:
+    - php
     build: ./php
     ports:
     - "8080:80"
   go-be-service:
+    profiles:
+      - go
     build: ./go
     env_file:
     - ./go/.env
@@ -13,6 +17,7 @@ services:
     depends_on:
       mariadb-service:
         condition: service_started
+    
   mariadb-service:
     image: mariadb:latest
     container_name: mariadb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     profiles:
     - php
     build: ./php
+    env_file:
+      - ./php/.env
     ports:
     - "8080:80"
   go-be-service:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,10 +35,10 @@ services:
     ports:
       - "3306:3306"
     healthcheck:
-    test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
-    interval: 10s
-    timeout: 5s
-    retries: 5
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
   redis:
     image: redis:latest
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
       - ./php/.env
     ports:
     - "8080:80"
+    depends_on:
+    mariadb-service:
+      condition: service_started
   go-be-service:
     profiles:
       - go

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
     ports:
     - "8080:80"
     depends_on:
-    mariadb-service:
-      condition: service_started
+      mariadb-service:
+        condition: service_started
   go-be-service:
     profiles:
       - go

--- a/go/authentication/authentication.go
+++ b/go/authentication/authentication.go
@@ -23,7 +23,7 @@ type JWTSettings struct {
 
 var JwtVariables JWTSettings
 
-// TODO: implement rotating keys with a db
+// TODO: implement rotating keys with a redisdb
 
 // CreateNewJWT creates a new jwt with a userId payload and set's the expiration times based on if the creation should be a refreshToken
 func CreateNewJWT(userId int, isRT bool) (string, error) {

--- a/go/utils/loadEnv.go
+++ b/go/utils/loadEnv.go
@@ -37,7 +37,7 @@ func SetEnvVariables(parts []string) error {
 
 	var err error = nil
 	switch parts[0] {
-	case "JWT_KEY":
+	case "JWT_SECRET":
 		authentication.JwtVariables.Key = []byte(parts[1])
 	case "JWT_EXPIRATION_TIME_AT":
 		authentication.JwtVariables.ExpirationTime, err = strconv.Atoi(parts[1])

--- a/php/endpoints/admin_endpoint.php
+++ b/php/endpoints/admin_endpoint.php
@@ -1,9 +1,11 @@
 <?php
 
-class AdministratorEndpoint extends Endpoint{
+class AdministratorEndpoint extends Endpoint
+{
     use CommandHandlingTrait;
 
-    public function __construct(string $command, array $params, AuthenticationHandler &$authHandler){
+    public function __construct(string $command, array $params, AuthenticationHandler &$authHandler)
+    {
         parent::__construct($command, $params, $authHandler);
 
         $this->registerCommand('setupDatabase', 'setupDatabase');
@@ -11,8 +13,9 @@ class AdministratorEndpoint extends Endpoint{
         $this->registerCommand('resetDatabase', 'resetDatabase');
     }
 
-    private function setupDatabase(){
-        if( !DEVELOPER_MODE_ENABLED ){
+    private function setupDatabase()
+    {
+        if (!DEVELOPER_MODE_ENABLED) {
             return;
         }
 
@@ -20,8 +23,9 @@ class AdministratorEndpoint extends Endpoint{
         return $setupService->setupDatabase();
     }
 
-    private function initDefinitionData() : InternalStatus{
-        if( !DEVELOPER_MODE_ENABLED ){
+    private function initDefinitionData(): InternalStatus
+    {
+        if (!DEVELOPER_MODE_ENABLED) {
             return new InternalStatus(RequestStatus::DevModeRequired);
         }
 
@@ -29,8 +33,9 @@ class AdministratorEndpoint extends Endpoint{
         return $setupService->initDefinitionData();
     }
 
-    private function resetDatabase() : InternalStatus{
-        if( !DEVELOPER_MODE_ENABLED ){
+    private function resetDatabase(): InternalStatus
+    {
+        if (!DEVELOPER_MODE_ENABLED) {
             return new InternalStatus(RequestStatus::DevModeRequired);
         }
 
@@ -38,5 +43,3 @@ class AdministratorEndpoint extends Endpoint{
         return $setupService->resetDatabase();
     }
 }
-
-?>


### PR DESCRIPTION
This pull request includes several changes to improve the testing workflows and code formatting. The most important changes include the addition of a new GitHub Actions workflow for PHP end-to-end tests, fixing a typo in a test script, and reformatting the `AdministratorEndpoint` class in PHP.

Improvements to testing workflows:

* [`.github/workflows/php_api_test.yml`](diffhunk://#diff-26d6e2d4da3c73cb675d959de429170fecdcf7ff8e8f3d6c3e44ad7eb7372935R1-R62): Added a new GitHub Actions workflow for PHP end-to-end tests, including steps to set up Docker Compose, wait for API services, and run API test scenarios using Apidog CLI.

Code quality improvements:

* [`.github/workflows/go_api_test.yml`](diffhunk://#diff-0799c1ed89f2235389e69f24ad91227dd7156e393400b86d0b409445f04e4013L55-R55): Fixed a typo in the test script from "helthy" to "healthy".
* [`php/endpoints/admin_endpoint.php`](diffhunk://#diff-ca6e7ba93cad76be4a1bb76555a1fa36a0317303667d1fd5373d87de97b80a2bL3-R17): Reformatted the `AdministratorEndpoint` class to follow PSR-12 coding standards, including proper brace placement and spacing. [[1]](diffhunk://#diff-ca6e7ba93cad76be4a1bb76555a1fa36a0317303667d1fd5373d87de97b80a2bL3-R17) [[2]](diffhunk://#diff-ca6e7ba93cad76be4a1bb76555a1fa36a0317303667d1fd5373d87de97b80a2bL23-R27) [[3]](diffhunk://#diff-ca6e7ba93cad76be4a1bb76555a1fa36a0317303667d1fd5373d87de97b80a2bL32-R37) [[4]](diffhunk://#diff-ca6e7ba93cad76be4a1bb76555a1fa36a0317303667d1fd5373d87de97b80a2bL41-L42)