### PR TITLE
add read jwt from env

### DIFF
--- a/.github/workflows/go_api_test.yml
+++ b/.github/workflows/go_api_test.yml
@@ -34,6 +34,10 @@ jobs:
           echo "DB_HOST=${{secrets.DB_HOST}}" >> go/.env
           echo "DB_PORT=${{ secrets.DB_PORT }}" >> go/.env
           echo "DB_NAME=${{ secrets.DB_NAME }}" >> go/.env
+          echo "JWT_KEY=${{secrets.JWT_KEY}}" >> go/.env
+          echo "JWT_EXPIRATION_TIME_AT=${{secrets.JWT_EXPIRATION_TIME_AT}}" >> go/.env
+          echo "JWT_EXPIRATION_TIME_RT=${{secrets.JWT_EXPIRATION_TIME_AT}}" >> go/.env
+          echo "JWT_ISSUER=${{secrets.JWT_ISSUER}}" >> go/.env
 
       - name: Start Docker Compose services
         env:

--- a/go/authentication/authentication.go
+++ b/go/authentication/authentication.go
@@ -14,21 +14,26 @@ type EcoUserClaims struct {
 	jwt.RegisteredClaims
 }
 
-var JwtVariables struct {
+type JWTSettings struct {
 	Key              []byte
 	ExpirationTime   int
 	ExpirationTimeRT int
 	Issuer           string
 }
 
+var JwtVariables JWTSettings
+
 // TODO: implement rotating keys with a db
 
 // CreateNewJWT creates a new jwt with a userId payload and set's the expiration times based on if the creation should be a refreshToken
 func CreateNewJWT(userId int, isRT bool) (string, error) {
+	fmt.Println(JwtVariables.ExpirationTime)
 	expirationTime := time.Duration(JwtVariables.ExpirationTime) * time.Second
 	if isRT {
 		expirationTime = time.Duration(JwtVariables.ExpirationTimeRT) * time.Second
 	}
+	fmt.Println(expirationTime)
+	fmt.Println(time.Now().Add(expirationTime))
 	claims := EcoUserClaims{
 		userId,
 		jwt.RegisteredClaims{

--- a/go/authentication/authentication.go
+++ b/go/authentication/authentication.go
@@ -14,25 +14,32 @@ type EcoUserClaims struct {
 	jwt.RegisteredClaims
 }
 
+var JwtVariables struct {
+	Key              []byte
+	ExpirationTime   int
+	ExpirationTimeRT int
+	Issuer           string
+}
+
 // TODO: implement rotating keys with a db
-var jWTKey = []byte("testKeyEcoLand")
 
 // CreateNewJWT creates a new jwt with a userId payload and set's the expiration times based on if the creation should be a refreshToken
 func CreateNewJWT(userId int, isRT bool) (string, error) {
-	expirationTime := 5 * time.Minute
+	expirationTime := time.Duration(JwtVariables.ExpirationTime) * time.Second
 	if isRT {
-		expirationTime = 12 * time.Minute
+		expirationTime = time.Duration(JwtVariables.ExpirationTimeRT) * time.Second
 	}
 	claims := EcoUserClaims{
 		userId,
 		jwt.RegisteredClaims{
+			Issuer:    JwtVariables.Issuer,
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(expirationTime)),
 		},
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS512, claims)
-	st, err := token.SignedString(jWTKey)
+	st, err := token.SignedString(JwtVariables.Key)
 	if err != nil {
 		log.Println("jwt error", err)
 		return "", fmt.Errorf("could not create and sign jwt %w", err)
@@ -44,7 +51,7 @@ func CreateNewJWT(userId int, isRT bool) (string, error) {
 // ValidateJWT validates a given jwt and return the EcoUserClaims if valid
 func ValidateJWT(t string) (EcoUserClaims, error) {
 	vt, err := jwt.ParseWithClaims(t, &EcoUserClaims{}, func(t *jwt.Token) (interface{}, error) {
-		return jWTKey, nil
+		return JwtVariables.Key, nil
 	})
 
 	isValid := err == nil && vt.Valid

--- a/go/authentication/authentication_test.go
+++ b/go/authentication/authentication_test.go
@@ -1,16 +1,22 @@
 package authentication
 
 import (
+	"fmt"
 	"testing"
 )
 
 const userId = 1
 const isRT = true
-const nIsRt = false
 
 var validToken string
 
 func TestCreatNewJWT(t *testing.T) {
+	JwtVariables = JWTSettings{
+		Key:              []byte("Key"),
+		ExpirationTime:   100,
+		ExpirationTimeRT: 1000,
+		Issuer:           "Issuer",
+	}
 
 	t.Run("create NewJWT", func(t *testing.T) {
 		st, err := CreateNewJWT(userId, isRT)
@@ -29,6 +35,7 @@ func TestValidateJWT(t *testing.T) {
 	t.Run("valid JWT", func(t *testing.T) {
 		claims, err := ValidateJWT(validToken)
 		if err != nil {
+			fmt.Println(err)
 			t.Errorf("the jwt could not be validated correctly")
 		}
 		if claims.UserId != 1 {

--- a/go/docker-compose.yml
+++ b/go/docker-compose.yml
@@ -1,5 +1,7 @@
 services:
   go-service:
+    profiles:
+      - go
     build: .
     ports:
       - "8082:8081"

--- a/go/utils/loadEnv.go
+++ b/go/utils/loadEnv.go
@@ -3,7 +3,10 @@ package utils
 import (
 	"bufio"
 	"os"
+	"strconv"
 	"strings"
+
+	"github.com/FiSeStRo/Ecoland-Backend-Service/authentication"
 )
 
 func LoadEnv(filename string) error {
@@ -21,11 +24,29 @@ func LoadEnv(filename string) error {
 			continue
 		}
 		parts := strings.SplitN(line, "=", 2)
-		err = os.Setenv(parts[0], parts[1])
+		err = SetEnvVariables(parts)
 		if err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func SetEnvVariables(parts []string) error {
+
+	var err error = nil
+	switch parts[0] {
+	case "JWT_KEY":
+		authentication.JwtVariables.Key = []byte(parts[1])
+	case "JWT_EXPIRATION_TIME_AT":
+		authentication.JwtVariables.ExpirationTime, err = strconv.Atoi(parts[1])
+	case "JWT_EXPIRATION_TIME_RT":
+		authentication.JwtVariables.ExpirationTimeRT, err = strconv.Atoi(parts[1])
+	case "JWT_Issuer":
+		authentication.JwtVariables.Issuer = parts[1]
+	default:
+		err = os.Setenv(parts[0], parts[1])
+	}
+	return err
 }


### PR DESCRIPTION
This pull request includes several changes to the authentication and environment configuration of the Go service. The most important changes involve the introduction of a structured way to handle JWT variables and the modification of the environment loading process to support these new variables.

### Authentication improvements:

* Introduced `JwtVariables` struct to hold JWT configuration variables such as key, expiration times, and issuer. This replaces the hardcoded values previously used. (`go/authentication/authentication.go`)
* Updated `CreateNewJWT` and `ValidateJWT` functions to use the new `JwtVariables` struct for setting expiration times and signing keys. (`go/authentication/authentication.go`)

### Environment configuration:

* Added a `SetEnvVariables` function to handle the assignment of environment variables to the `JwtVariables` struct. This function is called within `LoadEnv` to process JWT-related environment variables. (`go/utils/loadEnv.go`)
* Modified the `LoadEnv` function to call `SetEnvVariables` instead of directly setting environment variables. (`go/utils/loadEnv.go`)

### Docker configuration:

* Added a profile for the Go service in the `docker-compose.yml` file to support different configurations. (`go/docker-compose.yml`)