### PR TITLE
bring secrets back

### DIFF
--- a/.github/workflows/php_api_test.yml
+++ b/.github/workflows/php_api_test.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Create php/.env file
         run: |
           mkdir -p php
-          echo "DB_USER=maria" > php/.env
-          echo "DB_PW=maria123" >> php/.env
-          echo "DB_HOST=mariadb-service" >> php/.env
-          echo "DB_PORT=3306" >> php/.env
-          echo "DB_NAME=mariadb" >> php/.env
+          echo "DB_USER=${{secrets.DB_USER}}" > php/.env
+          echo "DB_PW=${{secrets.DB_PW}}" >> php/.env
+          echo "DB_HOST=${{secrets.DB_HOST}}" >> php/.env
+          echo "DB_PORT=${{secrets.DB_PORT}}" >> php/.env
+          echo "DB_NAME=${{secrets.DB_NAME}}" >> php/.env
           echo "JWT_SECRET=${{secrets.JWT_SECRET}}" >> php/.env
           echo "JWT_EXPIRATION_TIME_AT=${{secrets.JWT_EXPIRATION_TIME_AT}}" >> php/.env
           echo "JWT_EXPIRATION_TIME_RT=${{secrets.JWT_EXPIRATION_TIME_AT}}" >> php/.env
@@ -36,11 +36,11 @@ jobs:
 
       - name: Start docker-compose service
         env:
-          DB_PW: maria123
-          DB_USER: maria
-          DB_HOST: mariadb-service
-          DB_NAME: mariadb
-          DB_PORT: 3306
+          DB_PW: ${{secrets.DB_PW}}
+          DB_USER: ${{secrets.DB_USER}}
+          DB_HOST: ${{secrets.DB_HOST}}
+          DB_NAME: ${{secrets.DB_NAME}}
+          DB_PORT: ${{secrets.DB_PORT}}
           JWT_EXPIRATION_TIME_AT: ${{secrets.JWT_EXPIRATION_TIME_AT}}
           JWT_EXPIRATION_TIME_RT: ${{secrets.JWT_EXPIRATION_TIME_RT}}
           JWT_SECRET: ${{secrets.JWT_SECRET}}


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/php_api_test.yml` file to enhance security by using GitHub secrets for sensitive information.

Security improvements:

* Updated the creation of the `php/.env` file to use GitHub secrets for database credentials and JWT settings.
* Modified the environment variables used to start the docker-compose service to use GitHub secrets for database credentials and JWT settings.