### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/go/authentication/authentication.go
+++ b/go/authentication/authentication.go
@@ -75,7 +75,7 @@ func ValidateAuthentication(req *http.Request) (EcoUserClaims, error) {
 	authHeader := req.Header.Get("Authorization")
 
 	if len(authHeader) < 7 && authHeader[:7] != "Bearer " {
-		log.Println("wrong header", authHeader)
+		log.Println("wrong header format")
 		return EcoUserClaims{}, fmt.Errorf("wrong authentication header")
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/FiSeStRo/Ecoland-Backend-Service/security/code-scanning/1](https://github.com/FiSeStRo/Ecoland-Backend-Service/security/code-scanning/1)

To fix the problem, we should avoid logging the entire `Authorization` header. Instead, we can log a generic message indicating that the header was incorrect without including its value. This approach maintains the functionality of logging errors while protecting sensitive information.

We need to modify the logging statement on line 78 to remove the `authHeader` value. The new log message should be generic and not include any potentially sensitive data.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
