### PR TITLE
add lan lat to building construction

### DIFF
--- a/docs/database/dbdiagram.md
+++ b/docs/database/dbdiagram.md
@@ -1,5 +1,6 @@
-// Use DBML to define your database structure
-// Docs: https://dbml.dbdiagram.io/docs
+# Database Structure from dbDiagram
+
+[docs](https://dbml.dbdiagram.io/docs)
 
 Project eco_land {
 database_type: 'MariaDb'

--- a/go/database/database.go
+++ b/go/database/database.go
@@ -48,6 +48,8 @@ func initaliseBuildingTables() {
 	user_id INT NOT NULL,
 	def_id INT NOT NULL,
 	name VARCHAR(255),
+	lan INT NOT NULL,
+	lat INT NOT NULL,
 	time_build TIMESTAMP NOT NULL
 	)`
 

--- a/go/service/building.go
+++ b/go/service/building.go
@@ -36,6 +36,8 @@ type Def_Building struct {
 type ConstructRequest struct {
 	Def_id       int    `json:"def_id"`
 	Display_name string `json:"display_name"`
+	Lan          int    `json:"lan"`
+	Lat          int    `json:"lat"`
 }
 
 // ConstrucitonList service to retrive a list of possible constructions
@@ -124,8 +126,8 @@ func ConstructBuilding(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	stmt, err := db.Prepare(`INSERT INTO buildings (user_id, def_id, name, time_build)
-	VALUES (?, ?, ?, CURRENT_TIMESTAMP)`)
+	stmt, err := db.Prepare(`INSERT INTO buildings (user_id, def_id, name, lan, lat time_build)
+	VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`)
 	if err != nil {
 		log.Println("Error preparing data insert", err)
 		http.Error(w, "Error Preparing data insert", http.StatusInternalServerError)
@@ -133,7 +135,7 @@ func ConstructBuilding(w http.ResponseWriter, req *http.Request) {
 	}
 	defer stmt.Close()
 
-	result, err := stmt.Exec(claims.UserId, constructReq.Def_id, constructReq.Display_name)
+	result, err := stmt.Exec(claims.UserId, constructReq.Def_id, constructReq.Display_name, constructReq.Lan, constructReq.Lat)
 	if err != nil {
 		http.Error(w, "Error constructing new building", http.StatusInternalServerError)
 		return


### PR DESCRIPTION
This pull request includes changes to the database schema and the corresponding service logic to add new fields for storing latitude and longitude information. Additionally, a minor update to the documentation was made.

### Database schema updates:

* [`go/database/database.go`](diffhunk://#diff-239140099aa154a13aebec5695dfa71256745ba75cd80642a06273a8bde0cf03R51-R52): Added `lan` and `lat` columns to the building tables to store latitude and longitude information.

### Service logic updates:

* [`go/service/building.go`](diffhunk://#diff-71f34df9bbd45232b957e21ff19378a081295dd088efcbdd428c8e8f2ed84682R39-R40): Updated the `ConstructRequest` struct to include `Lan` and `Lat` fields.
* [`go/service/building.go`](diffhunk://#diff-71f34df9bbd45232b957e21ff19378a081295dd088efcbdd428c8e8f2ed84682L127-R138): Modified the `ConstructBuilding` function to handle the new `lan` and `lat` fields in the SQL insert statement.

### Documentation update:

* [`docs/database/dbdiagram.md`](diffhunk://#diff-9669208e964bf4449aa69ed30dc6f1fb9777b1e76ac2b382cefc8dc0713e5238L1-R3): Updated the documentation to reflect the new database structure and corrected the reference link.